### PR TITLE
fixed an issue that would cause crawlme to encounter an error when handl...

### DIFF
--- a/lib/crawlme.js
+++ b/lib/crawlme.js
@@ -84,8 +84,10 @@ exports = module.exports = function(options) {
         var links = browser.queryAll('a');
         links.forEach(function(link) {
           var href = link.getAttribute('href');
-          var absoluteUrl = urlParser.resolve(url, href);
-          link.setAttribute('href', absoluteUrl);
+          if(href !== null) {
+            var absoluteUrl = urlParser.resolve(url, href);
+            link.setAttribute('href', absoluteUrl);
+          }
         });
 
         var snapshot = stripScripts(browser.html());


### PR DESCRIPTION
...ing incorrect html (<a> without href attribute)

Caught exception: TypeError: Parameter 'url' must be a string, not object
TypeError: Parameter 'url' must be a string, not object

This would happen because url = null in the case where the href attribute is not defined in the HTML
