### PR TITLE
Fixed an error in page crawling which is likely caused by an API change ...

### DIFF
--- a/lib/crawlme.js
+++ b/lib/crawlme.js
@@ -75,8 +75,7 @@ exports = module.exports = function(options) {
       if(cached) return cb(null, cached);
     }
 
-    var browser = new Browser();
-    browser.visit(url, {waitFor: options.waitFor},
+    Browser.visit(url, {waitFor: options.waitFor},
       function(err, browser, status) {
         if(err) return cb(err);
 


### PR DESCRIPTION
...in zombie.js

The .visit() method, the way it is being used here, expecting 3 variables in the callback (err, browser, status), should be a static method, rather than an instance method.

The instance method in zombie.js does not give the callback those 3 variables, causing "var links = browser.queryAll('a');" to throw an exception, as browser will be null.

Reference: https://github.com/assaf/zombie
